### PR TITLE
RUN cd /build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ruby:2.3
 COPY . /build
-RUN cd build && \
+RUN cd /build && \
     bundle install
 ENTRYPOINT [ "/usr/local/bundle/bin/wayback_machine_downloader" ]


### PR DESCRIPTION
Using `RUN cd /build` ensures proper context.